### PR TITLE
Pulling Test Branch to Main

### DIFF
--- a/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.agent.xml
+++ b/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.ask.xml
+++ b/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.edit.xml
+++ b/.idea/.idea.Pelican Keeper/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/Pelican Keeper Unit Testing/PlayerCountResponseTesting.cs
+++ b/Pelican Keeper Unit Testing/PlayerCountResponseTesting.cs
@@ -41,7 +41,7 @@ public class PlayerCountResponseTesting
                     {
                         RconService rcon = new RconService(_ip, (int)_port, _password);
                         await rcon.Connect();
-                        response = await rcon.SendCommandAsync(_command);
+                        response = await rcon.SendCommandAsync(_command, null);
                     }
                     else
                     {
@@ -51,12 +51,18 @@ public class PlayerCountResponseTesting
                 }
                 case CommandExecutionMethod.MinecraftJava:
                 {
-                    response = await JavaMinecraftQueryService.GetPlayerCountsAsync(_ip, (int)_port);
+                    JavaMinecraftQueryService javaMinecraftQuery = new JavaMinecraftQueryService(_ip, (int)_port);
+        
+                    await javaMinecraftQuery.Connect();
+                    response = await javaMinecraftQuery.SendCommandAsync();
                     break;
                 }
                 case CommandExecutionMethod.MinecraftBedrock:
                 {
-                    response = await BedrockMinecraftQueryService.GetPlayerCountsAsync(_ip, (int)_port);
+                    BedrockMinecraftQueryService bedrockMinecraftQuery = new BedrockMinecraftQueryService(_ip, (int)_port);
+        
+                    await bedrockMinecraftQuery.Connect();
+                    response = await bedrockMinecraftQuery.SendCommandAsync();
                     break;
                 }
                 case null:
@@ -68,7 +74,7 @@ public class PlayerCountResponseTesting
         
         if (!string.IsNullOrEmpty(response))
         {
-            var cleanResponse = HelperClass.ServerPlayerCountDisplayCleanup(response, null, 30);
+            var cleanResponse = HelperClass.ServerPlayerCountDisplayCleanup(response, 30);
             var playerMaxPlayer = Regex.Match(cleanResponse, @"^(\d+)\/\d+$");
             if (playerMaxPlayer.Success)
             {

--- a/Pelican Keeper Unit Testing/PlayerCountResponseTesting.cs
+++ b/Pelican Keeper Unit Testing/PlayerCountResponseTesting.cs
@@ -1,0 +1,88 @@
+﻿using System.Text.RegularExpressions;
+using Pelican_Keeper;
+using Pelican_Keeper.Query_Services;
+
+namespace Pelican_Keeper_Unit_Testing;
+using static TemplateClasses;
+
+public class PlayerCountResponseTesting
+{
+    private readonly string? _ip = null;
+    private readonly int? _port = null;
+    private readonly string? _password = null;
+    private readonly string? _command = null;
+    private readonly CommandExecutionMethod? _messageFormat = CommandExecutionMethod.A2S;
+    
+    [SetUp]
+    public void Setup()
+    {
+        
+    }
+
+    [Test]
+    public async Task PlayerCountResponseTest()
+    {
+        string? response = null;
+        if (_ip != null && _port != null && _messageFormat != null)
+        {
+            switch (_messageFormat)
+            {
+                case CommandExecutionMethod.A2S:
+                {
+                    A2SService a2S = new A2SService(_ip, (int)_port);
+        
+                    await a2S.Connect();
+                    response = await a2S.SendCommandAsync();
+                    break;
+                }
+                case CommandExecutionMethod.Rcon:
+                {
+                    if (_password != null && _command != null)
+                    {
+                        RconService rcon = new RconService(_ip, (int)_port, _password);
+                        await rcon.Connect();
+                        response = await rcon.SendCommandAsync(_command);
+                    }
+                    else
+                    {
+                        ConsoleExt.WriteLineWithPretext($"Password or Command is null. Password: {_password}, Command: {_command}");
+                    }
+                    break;
+                }
+                case CommandExecutionMethod.Minecraft:
+                {
+                    response = await MinecraftQueryService.GetPlayerCountsAsync(_ip, (int)_port);
+                    break;
+                }
+                case null:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+        
+        if (!string.IsNullOrEmpty(response))
+        {
+            var cleanResponse = HelperClass.ServerPlayerCountDisplayCleanup(response, null, 30);
+            var playerMaxPlayer = Regex.Match(cleanResponse, @"^(\d+)\/\d+$");
+            if (playerMaxPlayer.Success)
+            {
+                ConsoleExt.WriteLineWithPretext("Success! The Response Conforms to the output Standard!");
+                ConsoleExt.WriteLineWithPretext($"Response: {response}");
+                ConsoleExt.WriteLineWithPretext($"Clean Response: {cleanResponse}");
+                Assert.Pass($"{response}, {cleanResponse}");
+            }
+            else
+            {
+                ConsoleExt.WriteLineWithPretext("Failed! The Response does not Conform to the output Standard!");
+                ConsoleExt.WriteLineWithPretext($"Response: {response}");
+                ConsoleExt.WriteLineWithPretext($"Clean Response: {cleanResponse}");
+                Assert.Fail($"{response}, {cleanResponse}");
+            }
+        }
+        else
+        {
+            Assert.Fail("Response not returned or Empty!");
+        }
+    }
+}

--- a/Pelican Keeper Unit Testing/PlayerCountResponseTesting.cs
+++ b/Pelican Keeper Unit Testing/PlayerCountResponseTesting.cs
@@ -49,9 +49,14 @@ public class PlayerCountResponseTesting
                     }
                     break;
                 }
-                case CommandExecutionMethod.Minecraft:
+                case CommandExecutionMethod.MinecraftJava:
                 {
-                    response = await MinecraftQueryService.GetPlayerCountsAsync(_ip, (int)_port);
+                    response = await JavaMinecraftQueryService.GetPlayerCountsAsync(_ip, (int)_port);
+                    break;
+                }
+                case CommandExecutionMethod.MinecraftBedrock:
+                {
+                    response = await BedrockMinecraftQueryService.GetPlayerCountsAsync(_ip, (int)_port);
                     break;
                 }
                 case null:

--- a/Pelican Keeper Unit Testing/RconTesting.cs
+++ b/Pelican Keeper Unit Testing/RconTesting.cs
@@ -24,7 +24,7 @@ public class RconTesting
         }
 
         if (_secrets.ExternalServerIp != null)
-            await PelicanInterface.SendGameServerCommandRcon(_secrets.ExternalServerIp, 7777, "YouSuck", "listplayers"); // should load these from the secrets file and the information provided by the pelican API
+            await PelicanInterface.SendRconGameServerCommand(_secrets.ExternalServerIp, 7777, "YouSuck", "listplayers"); // should load these from the secrets file and the information provided by the pelican API
 
         if (ConsoleExt.ExceptionOccurred)
             Assert.Fail($"Test failed due to exception(s): {ConsoleExt.Exceptions}");

--- a/Pelican Keeper/A2SService.cs
+++ b/Pelican Keeper/A2SService.cs
@@ -127,8 +127,10 @@ public class A2SService(string ip, int port) : ISendCommand, IDisposable
     }
 
     /// <summary>
-    /// A2S_INFO request: 0xFF 0xFF 0xFF 0xFF 'T' "Source Engine Query\0" [optional 4-byte challenge LE]
+    /// Builds the A2S info packet with an optional challenge response.
     /// </summary>
+    /// <param name="challenge">The Solved Challenge</param>
+    /// <returns>Built A2S info Packet</returns>
     private static byte[] BuildA2SInfoPacket(int? challenge = null)
     {
         var head = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, (byte)'T' };
@@ -144,8 +146,10 @@ public class A2SService(string ip, int port) : ISendCommand, IDisposable
     }
 
     /// <summary>
-    /// Parses S2A_INFO (0x49) response. Returns "players/maxPlayers" or empty on failure.
+    /// Parses the A2S response.
     /// </summary>
+    /// <param name="buffer">The Response</param>
+    /// <returns>"players/maxPlayers" or empty on failure.</returns>
     private static string ParseA2SInfoResponse(byte[] buffer)
     {
         // Need at least header + 1 type byte

--- a/Pelican Keeper/Config.json
+++ b/Pelican Keeper/Config.json
@@ -4,6 +4,7 @@
   "MessageSorting": "Name",
   "MessageSortingDirection": "Ascending",
   "IgnoreOfflineServers": false,
+  "IgnoreInternalServers": false,
   "ServersToIgnore": ["UUIDS HERE"],
   
   "JoinableIpDisplay": true,

--- a/Pelican Keeper/Config.json
+++ b/Pelican Keeper/Config.json
@@ -15,6 +15,10 @@
   "EmptyServerTimeout": "00:01:00",
   "AllowUserServerStartup": true,
   "AllowServerStartup": ["UUIDS HERE"],
+  "UsersAllowedToStartServers": ["USERID HERE"],
+  "AllowUserServerStopping": true,
+  "AllowServerStopping": ["UUIDS HERE"],
+  "UsersAllowedToStopServers": ["USERID HERE"],
   
   "ContinuesMarkdownRead": true,
   "ContinuesGamesToMonitorRead": true,

--- a/Pelican Keeper/ConsoleExt.cs
+++ b/Pelican Keeper/ConsoleExt.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.ObjectModel;
 
 
 namespace Pelican_Keeper;
@@ -6,7 +7,9 @@ namespace Pelican_Keeper;
 public static class ConsoleExt
 {
     public static bool ExceptionOccurred;
-    public static readonly List<Exception> Exceptions = new();
+    public static IReadOnlyCollection<Exception> Exceptions => _exceptions;
+    // ReSharper disable once InconsistentNaming
+    private static readonly LinkedList<Exception> _exceptions = new();
     
     public enum OutputType
     {
@@ -39,7 +42,7 @@ public static class ConsoleExt
 
         if (exception == null) return length1 + length2;
         ExceptionOccurred = true;
-        Exceptions.Add(exception);
+        _exceptions.AddLast(exception);
         Console.WriteLine($"Exception: {exception.Message}");
         Console.WriteLine($"Stack Trace: {exception.StackTrace}");
         return length1 + length2;
@@ -68,7 +71,7 @@ public static class ConsoleExt
 
         if (exception == null) return length1 + length2;
         ExceptionOccurred = true;
-        Exceptions.Add(exception);
+        _exceptions.AddLast(exception);
         Console.WriteLine($"Exception: {exception.Message}");
         Console.WriteLine($"Stack Trace: {exception.StackTrace}");
         return length1 + length2;

--- a/Pelican Keeper/DiscordInteractions.cs
+++ b/Pelican Keeper/DiscordInteractions.cs
@@ -1,0 +1,256 @@
+﻿using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
+
+namespace Pelican_Keeper;
+
+using static ConsoleExt;
+using static Program;
+
+public class DiscordInteractions
+{
+    /// <summary>
+    /// Function that is called when a message is deleted in the target channel.
+    /// </summary>
+    /// <param name="sender">DiscordClient</param>
+    /// <param name="e">MessageDeleteEventArgs</param>
+    /// <returns>Task</returns>
+    internal static Task OnMessageDeleted(DiscordClient sender, MessageDeleteEventArgs e)
+    {
+        if (Secrets.ChannelIds != null && Secrets.ChannelIds.Contains(e.Message.Id)) return Task.CompletedTask;
+
+        var liveMessageTracked = LiveMessageStorage.Get(e.Message.Id);
+        if (liveMessageTracked != null)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext($"Live message {e.Message.Id} deleted in channel {e.Message.Channel.Name}. Removing from storage.");
+            LiveMessageStorage.Remove(liveMessageTracked);
+        }
+        else if (liveMessageTracked == null)
+        {
+            var paginatedMessageTracked = LiveMessageStorage.GetPaginated(e.Message.Id);
+            if (paginatedMessageTracked != null)
+            {
+                if (Config.Debug)
+                    WriteLineWithPretext($"Paginated message {e.Message.Id} deleted in channel {e.Message.Channel.Name}. Removing from storage.");
+                LiveMessageStorage.Remove(e.Message.Id);
+            }
+        }
+        return Task.CompletedTask;
+    }
+    
+    /// <summary>
+    /// Function that is called when a component interaction is created.
+    /// It handles the page flipping of the paginated message using buttons.
+    /// </summary>
+    /// <param name="sender">DiscordClient</param>
+    /// <param name="e">ComponentInteractionCreateEventArgs</param>
+    /// <returns>Task of Type Task</returns>
+    internal static async Task<Task> OnPageFlipInteraction(DiscordClient sender, ComponentInteractionCreateEventArgs e)
+    {
+        if (LiveMessageStorage.GetPaginated(e.Message.Id) is not { } pagedTracked || e.User.IsBot)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext("User is Bot or is not tracked, message ID is null.", ConsoleExt.OutputType.Warning);
+            return Task.CompletedTask;
+        }
+
+        int index = pagedTracked;
+
+        switch (e.Id)
+        {
+            case "next_page":
+                index = (index + 1) % EmbedPages.Count;
+                break;
+            case "prev_page":
+                index = (index - 1 + EmbedPages.Count) % EmbedPages.Count;
+                break;
+            default:
+                if (Config.Debug)
+                    WriteLineWithPretext("Unknown interaction ID: " + e.Id, ConsoleExt.OutputType.Warning);
+                return Task.CompletedTask;
+        }
+
+        LiveMessageStorage.Save(e.Message.Id, index);
+                
+        if (EmbedPages.Count == 0 || pagedTracked >= EmbedPages.Count)
+        {
+            WriteLineWithPretext("No pages to show or page index out of range", ConsoleExt.OutputType.Warning);
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            // treat "UUIDS HERE" placeholder or empty/null list as "allow all"
+            bool allowAllStart = Config.AllowServerStartup == null || Config.AllowServerStartup.Length == 0 || string.Equals(Config.AllowServerStartup[0], "UUIDS HERE", StringComparison.Ordinal);
+            WriteLineWithPretext("show all Start: " + allowAllStart);
+
+            // allow only if user-startup enabled, not ignoring offline, and either allow-all or in allow-list
+            bool showStart = Config is { AllowUserServerStartup: true, IgnoreOfflineServers: false, AllowServerStartup: not null } && (allowAllStart || Config.AllowServerStartup.Contains(GlobalServerInfo[index].Uuid, StringComparer.OrdinalIgnoreCase));
+            WriteLineWithPretext("show Start: " + showStart);
+            
+            // treat "UUIDS HERE" placeholder or empty/null list as "allow all"
+            bool allowAllStop = Config.AllowServerStopping == null || Config.AllowServerStopping.Length == 0 || string.Equals(Config.AllowServerStopping[0], "UUIDS HERE", StringComparison.Ordinal);
+            WriteLineWithPretext("show all Stop: " + allowAllStop);
+
+            // allow only if user-startup enabled, not ignoring offline, and either allow-all or in stop-list
+            bool showStop = Config is { AllowUserServerStopping: true, AllowServerStopping: not null } && (allowAllStop || Config.AllowServerStopping.Contains(GlobalServerInfo[index].Uuid, StringComparer.OrdinalIgnoreCase));
+            WriteLineWithPretext("show Stop: " + showStop);
+
+            var components = new List<DiscordComponent>
+            {
+                new DiscordButtonComponent(ButtonStyle.Primary, "prev_page", "◀️ Previous")
+            };
+            if (showStop)
+            {
+                components.Add(new DiscordButtonComponent(ButtonStyle.Primary, $"Start: {GlobalServerInfo[index].Uuid}", $"Start"));
+            }
+            if (showStop)
+            {
+                components.Add(new DiscordButtonComponent(ButtonStyle.Primary, $"Stop: {GlobalServerInfo[index].Uuid}", $"Stop"));
+            }
+            components.Add(new DiscordButtonComponent(ButtonStyle.Primary, "next_page", "Next ▶️"));
+            await e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage,
+                new DiscordInteractionResponseBuilder()
+                    .AddEmbed(EmbedPages[index])
+                    .AddComponents(components)
+            );
+        }
+        catch (NotFoundException nf)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext("Interaction expired or already responded to. Skipping. " + nf.Message, ConsoleExt.OutputType.Error);
+        }
+        catch (BadRequestException br)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext("Bad request during interaction: " + br.JsonMessage, ConsoleExt.OutputType.Error);
+        }
+        catch (Exception ex)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext("Unexpected error during component interaction: " + ex.Message, ConsoleExt.OutputType.Error);
+        }
+
+        return Task.CompletedTask;
+    }
+    
+    internal static async Task<Task> OnServerStartInteraction(DiscordClient sender, ComponentInteractionCreateEventArgs e)
+    {
+        if (e.User.IsBot)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext("User is a Bot!", ConsoleExt.OutputType.Warning);
+            return Task.CompletedTask;
+        }
+
+        if (!e.Id.ToLower().Contains("start") || Config.UsersAllowedToStartServers != null && string.Equals(Config.UsersAllowedToStartServers[0], "USERID HERE", StringComparison.Ordinal) && Config.UsersAllowedToStartServers.Length != 0 && !Config.UsersAllowedToStartServers.Contains(e.User.Id.ToString()))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (Config.Debug)
+            WriteLineWithPretext("User " + e.User.Username + " clicked button with ID: " + e.Id);
+        
+        var id = e.Id;
+        var server = GlobalServerInfo.FirstOrDefault(s => s.Uuid == id);
+        if (server == null)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext($"No server found with UUID {id}", ConsoleExt.OutputType.Warning);
+            return Task.CompletedTask;
+        }
+
+        if (server.Resources?.CurrentState.ToLower() == "offline")
+        {
+            PelicanInterface.SendPowerCommand(server.Uuid, "start");
+            if (Config.Debug)
+                WriteLineWithPretext("Start command sent to server " + server.Name);
+            await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
+        }
+        return Task.CompletedTask;
+    }
+    
+    internal static async Task<Task> OnServerStopInteraction(DiscordClient sender, ComponentInteractionCreateEventArgs e)
+    {
+        if (e.User.IsBot)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext("User is a Bot!", ConsoleExt.OutputType.Warning);
+            return Task.CompletedTask;
+        }
+        
+        if (!e.Id.ToLower().Contains("stop") || Config.UsersAllowedToStopServers != null && string.Equals(Config.UsersAllowedToStopServers[0], "USERID HERE", StringComparison.Ordinal) && Config.UsersAllowedToStopServers.Length != 0 && !Config.UsersAllowedToStopServers.Contains(e.User.Id.ToString()))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (Config.Debug)
+            WriteLineWithPretext("User " + e.User.Username + " clicked button with ID: " + e.Id);
+        
+        var id = e.Id;
+        var server = GlobalServerInfo.FirstOrDefault(s => s.Uuid == id);
+        if (server == null)
+        {
+            if (Config.Debug)
+                WriteLineWithPretext($"No server found with UUID {id}", ConsoleExt.OutputType.Warning);
+            return Task.CompletedTask;
+        }
+
+        if (server.Resources?.CurrentState.ToLower() == "online")
+        {
+            PelicanInterface.SendPowerCommand(server.Uuid, "stop");
+            if (Config.Debug)
+                WriteLineWithPretext("Stop command sent to server " + server.Name);
+            await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
+        }
+        return Task.CompletedTask;
+    }
+
+    internal static async Task<Task> OnDropDownInteration(DiscordClient sender, ComponentInteractionCreateEventArgs e)
+    {
+        if (e.User.IsBot) return Task.CompletedTask;
+            
+        switch (e.Id) //The Identifier of the dropdown
+        {
+            case "start_menu":
+            {
+                var uuid = e.Values.FirstOrDefault();
+                var serverInfo = GlobalServerInfo.FirstOrDefault(x => x.Uuid == uuid);
+                if (serverInfo != null)
+                {
+                    await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
+                        
+                    PelicanInterface.SendPowerCommand(serverInfo.Uuid, "stop");
+                        
+                    await e.Interaction.CreateFollowupMessageAsync(
+                        new DiscordFollowupMessageBuilder()
+                            .WithContent($"▶️ Starting server `{serverInfo.Name}`…")
+                            .AsEphemeral()
+                    );
+                }
+                break;
+            }
+            case "stop_menu":
+            {
+                var uuid = e.Values.FirstOrDefault();
+                var serverInfo = GlobalServerInfo.FirstOrDefault(x => x.Uuid == uuid);
+                if (serverInfo != null)
+                {
+                    await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
+                        
+                    PelicanInterface.SendPowerCommand(serverInfo.Uuid, "start");
+                        
+                    await e.Interaction.CreateFollowupMessageAsync(
+                        new DiscordFollowupMessageBuilder()
+                            .WithContent($"⏹ Stopping server `{serverInfo.Name}`…")
+                            .AsEphemeral()
+                    );
+                }
+                break;
+            }
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Pelican Keeper/DiscordInteractions.cs
+++ b/Pelican Keeper/DiscordInteractions.cs
@@ -136,12 +136,18 @@ public class DiscordInteractions
         return Task.CompletedTask;
     }
     
+    /// <summary>
+    /// Function that is called when the user interacts with the Start Button. It sends a start command to the Server in question
+    /// </summary>
+    /// <param name="sender">DiscordClient</param>
+    /// <param name="e">MessageDeleteEventArgs</param>
+    /// <returns>Task of Type Task</returns>
     internal static async Task<Task> OnServerStartInteraction(DiscordClient sender, ComponentInteractionCreateEventArgs e)
     {
         if (e.User.IsBot)
         {
             if (Config.Debug)
-                WriteLineWithPretext("User is a Bot!", ConsoleExt.OutputType.Warning);
+                WriteLineWithPretext("User is a Bot!", OutputType.Warning);
             return Task.CompletedTask;
         }
 
@@ -158,7 +164,7 @@ public class DiscordInteractions
         if (server == null)
         {
             if (Config.Debug)
-                WriteLineWithPretext($"No server found with UUID {id}", ConsoleExt.OutputType.Warning);
+                WriteLineWithPretext($"No server found with UUID {id}", OutputType.Warning);
             return Task.CompletedTask;
         }
 
@@ -172,12 +178,18 @@ public class DiscordInteractions
         return Task.CompletedTask;
     }
     
+    /// <summary>
+    /// Function that is called when the user interacts with the Stop Button. It sends a stop command to the Server in question
+    /// </summary>
+    /// <param name="sender">DiscordClient</param>
+    /// <param name="e">MessageDeleteEventArgs</param>
+    /// <returns>Task of Type Task</returns>
     internal static async Task<Task> OnServerStopInteraction(DiscordClient sender, ComponentInteractionCreateEventArgs e)
     {
         if (e.User.IsBot)
         {
             if (Config.Debug)
-                WriteLineWithPretext("User is a Bot!", ConsoleExt.OutputType.Warning);
+                WriteLineWithPretext("User is a Bot!", OutputType.Warning);
             return Task.CompletedTask;
         }
         
@@ -194,7 +206,7 @@ public class DiscordInteractions
         if (server == null)
         {
             if (Config.Debug)
-                WriteLineWithPretext($"No server found with UUID {id}", ConsoleExt.OutputType.Warning);
+                WriteLineWithPretext($"No server found with UUID {id}", OutputType.Warning);
             return Task.CompletedTask;
         }
 
@@ -208,6 +220,12 @@ public class DiscordInteractions
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Function that is called when the user interacts with the dropdown menu. It starts or stops the server you selected
+    /// </summary>
+    /// <param name="sender">DiscordClient</param>
+    /// <param name="e">MessageDeleteEventArgs</param>
+    /// <returns>Task of Type Task</returns>
     internal static async Task<Task> OnDropDownInteration(DiscordClient sender, ComponentInteractionCreateEventArgs e)
     {
         if (e.User.IsBot) return Task.CompletedTask;

--- a/Pelican Keeper/FileManager.cs
+++ b/Pelican Keeper/FileManager.cs
@@ -27,7 +27,7 @@ public static class FileManager
     {
         WriteLineWithPretext("Secrets.json not found. Creating default one.", OutputType.Warning);
         await using var secretsFile = File.Create("Secrets.json");
-        string defaultSecrets = new string("{\n  \"ClientToken\": \"YOUR_CLIENT_TOKEN\",\n  \"ServerToken\": \"YOUR_SERVER_TOKEN\",\n  \"ServerUrl\": \"YOUR_BASIC_SERVER_URL\",\n  \"BotToken\": \"YOUR_DISCORD_BOT_TOKEN\",\n  \"ChannelId\": THE_CHANNEL_ID_YOU_WANT_THE_BOT_TO_POST_IN,\n  \"ExternalServerIp\": \"YOUR_EXTERNAL_SERVER_IP\"\n}");
+        string defaultSecrets = new string("{\n  \"ClientToken\": \"YOUR_CLIENT_TOKEN\",\n  \"ServerToken\": \"YOUR_SERVER_TOKEN\",\n  \"ServerUrl\": \"YOUR_BASIC_SERVER_URL\",\n  \"BotToken\": \"YOUR_DISCORD_BOT_TOKEN\",\n  \"ChannelIds\": [THE_CHANNEL_ID_YOU_WANT_THE_BOT_TO_POST_IN],\n  \"ExternalServerIp\": \"YOUR_EXTERNAL_SERVER_IP\"\n}");
         await using var writer = new StreamWriter(secretsFile);
         await writer.WriteAsync(defaultSecrets);
         WriteLineWithPretext("Created default Secrets.json. Please fill out the values.", OutputType.Warning);
@@ -39,7 +39,7 @@ public static class FileManager
     private static async Task CreateConfigFile()
     {
         await using var configFile = File.Create("Config.json");
-        var defaultConfig = new string("{\n  \"InternalIpStructure\": \"192.168.*.*\",\n  \"MessageFormat\": \"Consolidated\",\n  \"MessageSorting\": \"Name\",\n  \"MessageSortingDirection\": \"Ascending\",\n  \"IgnoreOfflineServers\": false,\n  \"ServersToIgnore\": [\"UUIDS HERE\"],\n  \n  \"JoinableIpDisplay\": true,\n  \"PlayerCountDisplay\": true,\n  \n  \"AutomaticShutdown\": true,\n  \"ServersToAutoShutdown\": [\"UUIDS HERE\"],\n  \"EmptyServerTimeout\": \"00:01:00\",\n  \"AllowUserServerStartup\": true,\n  \"AllowServerStartup\": [\"UUIDS HERE\"],\n  \n  \"ContinuesMarkdownRead\": true,\n  \"ContinuesGamesToMonitorRead\": true,\n  \"MarkdownUpdateInterval\": 30,\n  \"ServerUpdateInterval\": 10,\n  \n  \"LimitServerCount\": false,\n  \"MaxServerCount\": 10,\n  \"ServersToDisplay\": [\"UUIDS HERE\"],\n  \n  \"Debug\": false,\n  \"DryRun\": false\n}");
+        var defaultConfig = new string("{\n  \"InternalIpStructure\": \"192.168.*.*\",\n  \"MessageFormat\": \"Consolidated\",\n  \"MessageSorting\": \"Name\",\n  \"MessageSortingDirection\": \"Ascending\",\n  \"IgnoreOfflineServers\": false,\n  \"ServersToIgnore\": [\"UUIDS HERE\"],\n  \n  \"JoinableIpDisplay\": false,\n  \"PlayerCountDisplay\": false,\n  \"ServersToMonitor\": [\"UUIDS HERE\"],\n  \n  \"AutomaticShutdown\": true,\n  \"ServersToAutoShutdown\": [\"UUIDS HERE\"],\n  \"EmptyServerTimeout\": \"00:01:00\",\n  \"AllowUserServerStartup\": true,\n  \"AllowServerStartup\": [\"UUIDS HERE\"],\n  \"UsersAllowedToStartServers\": [\"USERID HERE\"],\n  \"AllowUserServerStopping\": true,\n  \"AllowServerStopping\": [\"UUIDS HERE\"],\n  \"UsersAllowedToStopServers\": [\"USERID HERE\"],\n  \n  \"ContinuesMarkdownRead\": true,\n  \"ContinuesGamesToMonitorRead\": true,\n  \"MarkdownUpdateInterval\": 30,\n  \"ServerUpdateInterval\": 10,\n  \n  \"LimitServerCount\": false,\n  \"MaxServerCount\": 10,\n  \"ServersToDisplay\": [\"UUIDS HERE\"],\n  \n  \"Debug\": true,\n  \"DryRun\": false\n}");
         await using var writer = new StreamWriter(configFile);
         await writer.WriteAsync(defaultConfig);
     }

--- a/Pelican Keeper/FileManager.cs
+++ b/Pelican Keeper/FileManager.cs
@@ -71,6 +71,7 @@ public static class FileManager
         catch (Exception ex)
         {
             WriteLineWithPretext("Failed to load secrets. Check that the Secrets file is filled out and is in the correct format. Check Secrets.json", OutputType.Error, ex);
+            Environment.Exit(0);
             return null;
         }
 
@@ -96,12 +97,14 @@ public static class FileManager
         catch (Exception ex)
         {
             WriteLineWithPretext("Failed to load config. Check if nothing is misspelled and you used the correct options", OutputType.Error, ex);
+            Environment.Exit(0);
             return null;
         }
         
         if (config == null)
         {
             WriteLineWithPretext("Config file is empty or not in the correct format. Please check Config.json", OutputType.Error);
+            Environment.Exit(0);
             return null;
         }
         

--- a/Pelican Keeper/FileManager.cs
+++ b/Pelican Keeper/FileManager.cs
@@ -3,6 +3,7 @@
 namespace Pelican_Keeper;
 
 using static ConsoleExt;
+using static TemplateClasses;
 
 public static class FileManager
 {
@@ -39,7 +40,7 @@ public static class FileManager
     private static async Task CreateConfigFile()
     {
         await using var configFile = File.Create("Config.json");
-        var defaultConfig = new string("{\n  \"InternalIpStructure\": \"192.168.*.*\",\n  \"MessageFormat\": \"Consolidated\",\n  \"MessageSorting\": \"Name\",\n  \"MessageSortingDirection\": \"Ascending\",\n  \"IgnoreOfflineServers\": false,\n  \"ServersToIgnore\": [\"UUIDS HERE\"],\n  \n  \"JoinableIpDisplay\": false,\n  \"PlayerCountDisplay\": false,\n  \"ServersToMonitor\": [\"UUIDS HERE\"],\n  \n  \"AutomaticShutdown\": true,\n  \"ServersToAutoShutdown\": [\"UUIDS HERE\"],\n  \"EmptyServerTimeout\": \"00:01:00\",\n  \"AllowUserServerStartup\": true,\n  \"AllowServerStartup\": [\"UUIDS HERE\"],\n  \"UsersAllowedToStartServers\": [\"USERID HERE\"],\n  \"AllowUserServerStopping\": true,\n  \"AllowServerStopping\": [\"UUIDS HERE\"],\n  \"UsersAllowedToStopServers\": [\"USERID HERE\"],\n  \n  \"ContinuesMarkdownRead\": true,\n  \"ContinuesGamesToMonitorRead\": true,\n  \"MarkdownUpdateInterval\": 30,\n  \"ServerUpdateInterval\": 10,\n  \n  \"LimitServerCount\": false,\n  \"MaxServerCount\": 10,\n  \"ServersToDisplay\": [\"UUIDS HERE\"],\n  \n  \"Debug\": true,\n  \"DryRun\": false\n}");
+        var defaultConfig = new string("{\n  \"InternalIpStructure\": \"192.168.*.*\",\n  \"MessageFormat\": \"Consolidated\",\n  \"MessageSorting\": \"Name\",\n  \"MessageSortingDirection\": \"Ascending\",\n  \"IgnoreOfflineServers\": false,\n  \"IgnoreInternalServers\": false,\n  \"ServersToIgnore\": [\"UUIDS HERE\"],\n  \n  \"JoinableIpDisplay\": true,\n  \"PlayerCountDisplay\": true,\n  \"ServersToMonitor\": [\"UUIDS HERE\"],\n  \n  \"AutomaticShutdown\": true,\n  \"ServersToAutoShutdown\": [\"UUIDS HERE\"],\n  \"EmptyServerTimeout\": \"00:01:00\",\n  \"AllowUserServerStartup\": true,\n  \"AllowServerStartup\": [\"UUIDS HERE\"],\n  \"UsersAllowedToStartServers\": [\"USERID HERE\"],\n  \"AllowUserServerStopping\": true,\n  \"AllowServerStopping\": [\"UUIDS HERE\"],\n  \"UsersAllowedToStopServers\": [\"USERID HERE\"],\n  \n  \"ContinuesMarkdownRead\": true,\n  \"ContinuesGamesToMonitorRead\": true,\n  \"MarkdownUpdateInterval\": 30,\n  \"ServerUpdateInterval\": 10,\n  \n  \"LimitServerCount\": false,\n  \"MaxServerCount\": 10,\n  \"ServersToDisplay\": [\"UUIDS HERE\"],\n  \n  \"Debug\": false,\n  \"DryRun\": false\n}");
         await using var writer = new StreamWriter(configFile);
         await writer.WriteAsync(defaultConfig);
     }
@@ -59,7 +60,7 @@ public static class FileManager
     /// Reads the Secrets.json file and interprets it to the Secrets class structure.
     /// </summary>
     /// <returns>The interpreted Secrets in the Secrets class structure</returns>
-    public static async Task<TemplateClasses.Secrets?> ReadSecretsFile()
+    public static async Task<Secrets?> ReadSecretsFile()
     {
         string secretsPath = GetFilePath("Secrets.json");
         
@@ -69,11 +70,11 @@ public static class FileManager
             return null;
         }
 
-        TemplateClasses.Secrets? secrets;
+        Secrets? secrets;
         try
         {
             var secretsJson = await File.ReadAllTextAsync(secretsPath);
-            secrets = JsonSerializer.Deserialize<TemplateClasses.Secrets>(secretsJson)!;
+            secrets = JsonSerializer.Deserialize<Secrets>(secretsJson)!;
         }
         catch (Exception ex)
         {
@@ -90,7 +91,7 @@ public static class FileManager
     /// Reads the Config.json file and interprets it to the Config class structure.
     /// </summary>
     /// <returns>The interpreted Config in the Config class structure</returns>
-    public static async Task<TemplateClasses.Config?> ReadConfigFile()
+    public static async Task<Config?> ReadConfigFile()
     {
         string configPath = GetFilePath("Config.json");
         
@@ -99,11 +100,11 @@ public static class FileManager
             await CreateConfigFile();
         }
         
-        TemplateClasses.Config? config;
+        Config? config;
         try
         {
             var configJson = await File.ReadAllTextAsync(configPath);
-            config = JsonSerializer.Deserialize<TemplateClasses.Config>(configJson);
+            config = JsonSerializer.Deserialize<Config>(configJson);
         }
         catch (Exception ex)
         {
@@ -127,7 +128,7 @@ public static class FileManager
     /// Reads the GamesToMonitor.json file and interprets it to the GamesToMonitor class structure.
     /// </summary>
     /// <returns>The interpreted GamesToMonitor in the GamesToMonitor class structure</returns>
-    public static async Task<List<TemplateClasses.GamesToMonitor>?> ReadGamesToMonitorFile()
+    public static async Task<List<GamesToMonitor>?> ReadGamesToMonitorFile()
     {
         string gameCommPath = GetFilePath("GamesToMonitor.json");
         
@@ -140,7 +141,7 @@ public static class FileManager
         try
         {
             var gameCommJson = await File.ReadAllTextAsync(gameCommPath);
-            var gameComms = JsonSerializer.Deserialize<List<TemplateClasses.GamesToMonitor>>(gameCommJson);
+            var gameComms = JsonSerializer.Deserialize<List<GamesToMonitor>>(gameCommJson);
             return gameComms;
         }
         catch (Exception ex)

--- a/Pelican Keeper/FileManager.cs
+++ b/Pelican Keeper/FileManager.cs
@@ -17,7 +17,7 @@ public static class FileManager
         {
             return path;
         }
-        return File.Exists(Path.Combine("/Pelican Keeper/",path)) ? Path.Combine("/Pelican Keeper/",path) : string.Empty;
+        return File.Exists(Path.Combine(Environment.CurrentDirectory, "Pelican Keeper", path)) ? Path.Combine(Environment.CurrentDirectory, "Pelican Keeper", path) : string.Empty;
     }
 
     /// <summary>
@@ -44,6 +44,9 @@ public static class FileManager
         await writer.WriteAsync(defaultConfig);
     }
 
+    /// <summary>
+    /// Creates a default MessageMarkdown.txt file in the current execution directory.
+    /// </summary>
     public static async Task CreateMessageMarkdownFile()
     {
         await using var messageMarkdownFile = File.Create("MessageMarkdown.txt");
@@ -52,6 +55,10 @@ public static class FileManager
         await writer.WriteAsync(defaultConfig);
     }
     
+    /// <summary>
+    /// Reads the Secrets.json file and interprets it to the Secrets class structure.
+    /// </summary>
+    /// <returns>The interpreted Secrets in the Secrets class structure</returns>
     public static async Task<TemplateClasses.Secrets?> ReadSecretsFile()
     {
         string secretsPath = GetFilePath("Secrets.json");
@@ -79,6 +86,10 @@ public static class FileManager
         return secrets;
     }
     
+    /// <summary>
+    /// Reads the Config.json file and interprets it to the Config class structure.
+    /// </summary>
+    /// <returns>The interpreted Config in the Config class structure</returns>
     public static async Task<TemplateClasses.Config?> ReadConfigFile()
     {
         string configPath = GetFilePath("Config.json");
@@ -112,13 +123,17 @@ public static class FileManager
         return config;
     }
     
+    /// <summary>
+    /// Reads the GamesToMonitor.json file and interprets it to the GamesToMonitor class structure.
+    /// </summary>
+    /// <returns>The interpreted GamesToMonitor in the GamesToMonitor class structure</returns>
     public static async Task<List<TemplateClasses.GamesToMonitor>?> ReadGamesToMonitorFile()
     {
         string gameCommPath = GetFilePath("GamesToMonitor.json");
         
         if (gameCommPath == String.Empty)
         {
-            WriteLineWithPretext("GamesToMonitor.json not found. Creating default one.", OutputType.Error);//TODO: Add default creation of GamesToMonitor.json
+            WriteLineWithPretext("GamesToMonitor.json not found. Move it to the Main Directory for the bot to find it.", OutputType.Error);
             return null;
         }
 

--- a/Pelican Keeper/GamesToMonitor.json
+++ b/Pelican Keeper/GamesToMonitor.json
@@ -41,7 +41,7 @@
   {
     "Game": "Valheim",
     "Protocol": "A2S",
-    "QueryPortVariable": "SERVER_PORT+1",
+    "QueryPortVariable": "SERVER_PORT",
     "MaxPlayer": "10"
   }
 ]

--- a/Pelican Keeper/GamesToMonitor.json
+++ b/Pelican Keeper/GamesToMonitor.json
@@ -22,5 +22,15 @@
     "Game": "7 Days To Die",
     "Protocol": "A2S",
     "QueryPortVariable": "SERVER_PORT"
+  },
+  {
+    "Game": "Forge Minecraft",
+    "Protocol": "MinecraftJava",
+    "QueryPortVariable": "SERVER_PORT"
+  },
+  {
+    "Game": "NeoForge",
+    "Protocol": "MinecraftJava",
+    "QueryPortVariable": "SERVER_PORT"
   }
 ]

--- a/Pelican Keeper/GamesToMonitor.json
+++ b/Pelican Keeper/GamesToMonitor.json
@@ -32,5 +32,16 @@
     "Game": "NeoForge",
     "Protocol": "MinecraftJava",
     "QueryPortVariable": "SERVER_PORT"
+  },
+  {
+    "Game": "Purpur-Geyser-Floodgate",
+    "Protocol": "MinecraftBedrock",
+    "QueryPortVariable": "SERVER_PORT"
+  },
+  {
+    "Game": "Valheim",
+    "Protocol": "A2S",
+    "QueryPortVariable": "SERVER_PORT+1",
+    "MaxPlayer": "10"
   }
 ]

--- a/Pelican Keeper/HelperClass.cs
+++ b/Pelican Keeper/HelperClass.cs
@@ -133,8 +133,10 @@ public static class HelperClass
             return 0;
         }
 
-        var noPlayer = Regex.Match(serverResponse, @"(?i)\bNo\s+Players?\b[.!]?");
-        if (noPlayer.Success) return 0;
+        if (!serverResponse.Any(char.IsDigit))
+        {
+            return 0; // No digits found in the server response, so player count is 0 (probably a "no players" message or connection error/timeout)
+        }
         
         var playerMaxPlayer = Regex.Match(serverResponse, @"^(\d+)\/\d+$");
         if (playerMaxPlayer.Success && int.TryParse(playerMaxPlayer.Groups[1].Value, out var playerCount))

--- a/Pelican Keeper/HelperClass.cs
+++ b/Pelican Keeper/HelperClass.cs
@@ -288,7 +288,6 @@ public static class HelperClass
     public static void DebugDumpComponents(IEnumerable<DiscordComponent> comps)
     {
         int rows = 0, total = 0;
-        int rowCount = 0;
         var buffer = new List<DiscordComponent>(5);
 
         void FlushButtons()
@@ -336,7 +335,6 @@ public static class HelperClass
                     Console.WriteLine($"[WARN] Unknown component type: {c.GetType().Name}");
                     break;
             }
-            rowCount++;
         }
         FlushButtons();
         Console.WriteLine($"[SUMMARY] rows={rows}, total components={total}");

--- a/Pelican Keeper/ISendCommand.cs
+++ b/Pelican Keeper/ISendCommand.cs
@@ -4,5 +4,5 @@ public interface ISendCommand
 {
     public Task Connect();
     
-    public Task<string> SendCommandAsync(string command);
+    public Task<string> SendCommandAsync(string command, string regexPattern);
 }

--- a/Pelican Keeper/JsonHandler.cs
+++ b/Pelican Keeper/JsonHandler.cs
@@ -4,8 +4,13 @@ using static Pelican_Keeper.TemplateClasses;
 
 namespace Pelican_Keeper;
 
-public class JsonHandler
+public static class JsonHandler
 {
+    /// <summary>
+    /// Extracts a list of Eggs from the input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <returns>List of EggInfo that includes the ID and Name</returns>
     internal static List<EggInfo> ExtractEggInfo(string json)
     {
         using var doc = JsonDocument.Parse(json);
@@ -32,6 +37,13 @@ public class JsonHandler
         return eggs;
     }
     
+    /// <summary>
+    /// Extracts the RCON Port from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <param name="uuid">UUID of the Server</param>
+    /// <param name="variableName">Variable Name of the RCON Port in the Pelican Panel</param>
+    /// <returns>The RCON port if found or 0 if not found</returns>
     internal static int ExtractRconPort(string json, string uuid, string? variableName)
     {
         if (variableName != null)
@@ -80,6 +92,13 @@ public class JsonHandler
         return rconPort;
     }
     
+    /// <summary>
+    /// Extracts the RCON Password from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <param name="uuid">UUID of the Server</param>
+    /// <param name="variableName">Variable Name of the RCON Password in the Pelican Panel</param>
+    /// <returns>String of The Password if found or Empty string if not found</returns>
     internal static string ExtractRconPassword(string json, string uuid, string? variableName)
     {
         if (variableName == null || variableName.Trim() == string.Empty)
@@ -115,6 +134,13 @@ public class JsonHandler
         return rconPassword;
     }
     
+    /// <summary>
+    /// Extracts the Query Port from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <param name="uuid">UUID of the Server</param>
+    /// <param name="variableName">Variable Name of the Query Port in the Pelican Panel</param>
+    /// <returns>The Query port if found or 0 if not found</returns>
     internal static int ExtractQueryPort(string json, string uuid, string? variableName)
     {
         if (variableName != null)
@@ -163,6 +189,13 @@ public class JsonHandler
         return queryPort;
     }
     
+    /// <summary>
+    /// Extracts the max player count from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <param name="uuid">UUID of the Server</param>
+    /// <param name="variableName">Variable Name of the Max Player Count in the Pelican Panel</param>
+    /// <returns>The Max Player Count if found or 0 if not found</returns>
     public static int ExtractMaxPlayerCount(string json, string uuid, string? variableName)
     {
         if (variableName == null || variableName.Trim() == string.Empty)
@@ -195,6 +228,12 @@ public class JsonHandler
         return maxPlayers;
     }
 
+    /// <summary>
+    /// Extracts the Network Allocations from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <param name="serverUuid">Optional! UUID of the server you want to extract the Network allocations from</param>
+    /// <returns>List of ServerAlocation</returns>
     internal static List<ServerAllocation> ExtractNetworkAllocations(string json, string? serverUuid = null)
     {
         using var doc = JsonDocument.Parse(json);
@@ -233,6 +272,11 @@ public class JsonHandler
         return allocations;
     }
     
+    /// <summary>
+    /// Extracts the Server List from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <returns>List of ServerInfo of the extracted Servers</returns>
     internal static List<ServerInfo> ExtractServerListInfo(string json)
     {
         using var doc = JsonDocument.Parse(json);
@@ -263,6 +307,11 @@ public class JsonHandler
         return serverInfo;
     }
     
+    /// <summary>
+    /// Extracts the Server Resources from the Input JSON
+    /// </summary>
+    /// <param name="json">Input JSON</param>
+    /// <returns>Server Resources of that Server</returns>
     internal static ServerResources ExtractServerResources(string json)
     {
         using var doc = JsonDocument.Parse(json);

--- a/Pelican Keeper/JsonHandler.cs
+++ b/Pelican Keeper/JsonHandler.cs
@@ -199,7 +199,7 @@ public static class JsonHandler
     /// <returns>The Max Player Count if found or 0 if not found</returns>
     public static int ExtractMaxPlayerCount(string json, string uuid, string? variableName, string? maxPlayer)
     {
-        if (string.IsNullOrEmpty(maxPlayer))
+        if (!string.IsNullOrEmpty(maxPlayer))
         {
             if (int.TryParse(maxPlayer, out int intMaxPlayers))
             {

--- a/Pelican Keeper/JsonHandler.cs
+++ b/Pelican Keeper/JsonHandler.cs
@@ -188,16 +188,25 @@ public static class JsonHandler
 
         return queryPort;
     }
-    
+
     /// <summary>
     /// Extracts the max player count from the Input JSON
     /// </summary>
     /// <param name="json">Input JSON</param>
     /// <param name="uuid">UUID of the Server</param>
     /// <param name="variableName">Variable Name of the Max Player Count in the Pelican Panel</param>
+    /// <param name="maxPlayer">Optional! if max player is set, it uses that instead of the variable</param>
     /// <returns>The Max Player Count if found or 0 if not found</returns>
-    public static int ExtractMaxPlayerCount(string json, string uuid, string? variableName)
+    public static int ExtractMaxPlayerCount(string json, string uuid, string? variableName, string? maxPlayer)
     {
+        if (string.IsNullOrEmpty(maxPlayer))
+        {
+            if (int.TryParse(maxPlayer, out int intMaxPlayers))
+            {
+                return intMaxPlayers;
+            }
+        }
+        
         if (variableName == null || variableName.Trim() == string.Empty)
         {
             variableName = "MAX_PLAYERS";

--- a/Pelican Keeper/LiveMessageStorage.cs
+++ b/Pelican Keeper/LiveMessageStorage.cs
@@ -150,7 +150,7 @@ public static class LiveMessageStorage
     /// <param name="channels">list of target channels</param>
     /// <param name="messageId">discord message ID</param>
     /// <returns>bool whether the message exists</returns>
-    private static async Task<bool> MessageExistsAsync(List<DiscordChannel> channels, ulong messageId)
+    public static async Task<bool> MessageExistsAsync(List<DiscordChannel> channels, ulong messageId)
     {
         foreach (var channel in channels)
         {

--- a/Pelican Keeper/Pelican Keeper.csproj
+++ b/Pelican Keeper/Pelican Keeper.csproj
@@ -39,6 +39,7 @@
         </None>
         <None Update="GamesToMonitor.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
         </None>
     </ItemGroup>
 

--- a/Pelican Keeper/Program.cs
+++ b/Pelican Keeper/Program.cs
@@ -42,7 +42,7 @@ internal static class Program
             _ = FileManager.CreateMessageMarkdownFile();
         }
 
-        GetServersToMonitorFileAsync();
+        GetGamesToMonitorFileAsync();
         ServerMarkdown.GetMarkdownFileContentAsync();
 
         var discord = new DiscordClient(new DiscordConfiguration

--- a/Pelican Keeper/Program.cs
+++ b/Pelican Keeper/Program.cs
@@ -38,7 +38,7 @@ internal static class Program
 
         if (FileManager.GetFilePath("MessageMarkdown.txt") == String.Empty)
         {
-            Console.WriteLine("MessageMarkdown.txt not found. Creating default one.");
+            Console.WriteLine("MessageMarkdown.txt not found. Pulling Default from Github!");
             _ = FileManager.CreateMessageMarkdownFile();
         }
 
@@ -338,7 +338,7 @@ internal static class Program
                                 
                                 var msg = await channel.GetMessageAsync(cacheEntry.Key);
 
-                                if (EmbedHasChanged(uuids, updatedEmbed)) //TODO: If this is on the same page in both channels it wont update one of them
+                                if (EmbedHasChanged(uuids, updatedEmbed))
                                 {
                                     if (Config.Debug)
                                         WriteLineWithPretext($"Updating paginated message {cacheEntry.Key} on page {currentIndex}");

--- a/Pelican Keeper/Query Services/A2SService.cs
+++ b/Pelican Keeper/Query Services/A2SService.cs
@@ -76,7 +76,7 @@ public class A2SService(string ip, int port) : ISendCommand, IDisposable
             // 0x49 = 'I' = S2A_INFO (immediate info response, no challenge)
             if (header == 0x49)
             {
-                return ParseOrFail(first);
+                return ParseOrFail(first); //TODO: Do the Player count text format correction here before returning instead of outside the function to streamline the process
             }
 
             // Some servers may reply multi-packet (0xFE) or other types, but I will treat them as unsupported for now

--- a/Pelican Keeper/Query Services/BedrockMinecraftQueryService.cs
+++ b/Pelican Keeper/Query Services/BedrockMinecraftQueryService.cs
@@ -1,0 +1,114 @@
+﻿using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Pelican_Keeper.Query_Services;
+
+public static class BedrockMinecraftQueryService //TODO: This should inherit from the ISendCommand Interface
+{
+    // RakNet "magic" bytes used in ping/pong
+    private static readonly byte[] Magic =
+    {
+        0x00, 0xFF, 0xFF, 0x00, 0xFE, 0xFE, 0xFE, 0xFE,
+        0xFD, 0xFD, 0xFD, 0xFD, 0x12, 0x34, 0x56, 0x78
+    };
+
+    /// <summary>
+    /// Queries a Bedrock (MCPE) server via RakNet ping for player counts.
+    /// </summary>
+    /// <returns>"online/max" or a descriptive error string</returns>
+    public static async Task<string> GetPlayerCountsAsync(string host, int port = 19132, int timeoutMs = 3000)
+    {
+        using var cts = new CancellationTokenSource(timeoutMs);
+        using var udp = new UdpClient();
+        udp.Client.ReceiveTimeout = timeoutMs;
+
+        // Resolve host to IPEndPoint
+        IPAddress[] addrs = await Dns.GetHostAddressesAsync(host, cts.Token);
+        if (addrs.Length == 0) return "Error: host not found";
+        var endPoint = new IPEndPoint(addrs.First(), port);
+
+        // Build Unconnected Ping
+        // Structure: [0x01][8B time][16B magic][8B client GUID]
+        var packet = new byte[1 + 8 + 16 + 8];
+        packet[0] = 0x01; // ID_UNCONNECTED_PING
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        BinaryPrimitives.WriteInt64BigEndian(packet.AsSpan(1), nowMs);
+        Magic.CopyTo(packet, 1 + 8);
+        // client GUID can be anything; use random
+        var guid = RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+        BinaryPrimitives.WriteInt64BigEndian(packet.AsSpan(1 + 8 + 16), guid);
+
+        await udp.SendAsync(packet, packet.Length, endPoint);
+
+        UdpReceiveResult resp;
+        try
+        {
+            var recvTask = udp.ReceiveAsync();
+            var completed = await Task.WhenAny(recvTask, Task.Delay(timeoutMs, cts.Token));
+            if (completed != recvTask) return "Timed out waiting for server response.";
+            resp = recvTask.Result;
+        }
+        catch (SocketException)
+        {
+            return "Timed out waiting for server response.";
+        }
+
+        var buf = resp.Buffer;
+        if (buf.Length < 1 + 8 + 8 + 16 + 2) return "Error: response too short";
+        if (buf[0] != 0x1C) return $"Error: unexpected packet id 0x{buf[0]:X2}"; // ID_UNCONNECTED_PONG
+
+        int offset = 1;
+        // 8B time
+        offset += 8;
+        // 8B server GUID
+        offset += 8;
+
+        // 16B magic
+        if (!buf.AsSpan(offset, 16).SequenceEqual(Magic))
+            return "Error: bad magic";
+        offset += 16;
+
+        // Remaining is usually a length-prefixed MOTD string (UTF-8).
+        // Try to read a 2-byte length (BE or LE). If it doesn't match, treat the rest as raw string.
+        int remaining = buf.Length - offset;
+        string motdString;
+
+        if (remaining >= 2)
+        {
+            ushort beLen = BinaryPrimitives.ReadUInt16BigEndian(buf.AsSpan(offset, 2));
+            ushort leLen = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(offset, 2));
+
+            if (beLen > 0 && beLen <= remaining - 2)
+            {
+                motdString = Encoding.UTF8.GetString(buf, offset + 2, beLen);
+            }
+            else if (leLen > 0 && leLen <= remaining - 2)
+            {
+                motdString = Encoding.UTF8.GetString(buf, offset + 2, leLen);
+            }
+            else
+            {
+                motdString = Encoding.UTF8.GetString(buf, offset, remaining);
+            }
+        }
+        else
+        {
+            motdString = Encoding.UTF8.GetString(buf, offset, remaining);
+        }
+
+        // Expected format (semicolon-separated), e.g.:
+        // "MCPE;MOTD;Protocol;Version;Online;Max;ServerId;LevelName;GameMode;GameModeNum;PortV4;PortV6"
+        var parts = motdString.Split(';');
+        if (parts.Length < 6 || !string.Equals(parts[0], "MCPE", StringComparison.OrdinalIgnoreCase))
+            return "Error: invalid Bedrock pong";
+
+        // parts[4] = online, parts[5] = max
+        if (!int.TryParse(parts[4], out var online)) online = 0;
+        if (!int.TryParse(parts[5], out var max)) max = 0;
+
+        return $"{online}/{max}";
+    }
+}

--- a/Pelican Keeper/Query Services/MinecraftQueryService.cs
+++ b/Pelican Keeper/Query Services/MinecraftQueryService.cs
@@ -1,0 +1,150 @@
+﻿using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+
+namespace Pelican_Keeper.Query_Services;
+
+public static class MinecraftQueryService
+{
+    /// <summary>
+    /// Queries a Minecraft server (Java edition) for current/maximum players using the status protocol.
+    /// </summary>
+    /// <param name="host">Host IP</param>
+    /// <param name="port">Port of the Server</param>
+    /// <param name="timeoutMs">Timeout in Ms</param>
+    /// <param name="protocolVersion">Protocol Version</param>
+    /// <returns>String in the format of Players/MaxPlayers</returns>
+    /// <exception cref="InvalidDataException">An unexpected packet ID was returned by the Server</exception>
+    public static async Task<string> GetPlayerCountsAsync(string host, int port = 25565, int timeoutMs = 5000, int protocolVersion = 760)
+    {
+        using var cts = new CancellationTokenSource(timeoutMs);
+        using var client = new TcpClient();
+        await client.ConnectAsync(host, port, cts.Token);
+        await using var stream = client.GetStream();
+        
+        using (var ms = new MemoryStream())
+        {
+            WriteVarInt(ms, 0x00);                              // packet id
+            WriteVarInt(ms, protocolVersion);                   // protocol version (ignored for status, but still has to be included)
+            WriteString(ms, host);                              // server address
+            WriteUShort(ms, (ushort)port);                      // server port
+            WriteVarInt(ms, 0x01);                              // next state = status
+            await SendFramedAsync(stream, ms.ToArray(), cts.Token);
+        }
+        
+        await SendFramedAsync(stream, [0x00], cts.Token);
+        
+        var payload = await ReadPacketAsync(stream, cts.Token);
+        using var rms = new MemoryStream(payload);
+        
+        var packetId = ReadVarInt(rms);
+        if (packetId != 0x00) throw new InvalidDataException($"Unexpected packet id {packetId}.");
+
+        var jsonLen = ReadVarInt(rms);
+        var jsonBuf = new byte[jsonLen];
+        if (await rms.ReadAsync(jsonBuf, 0, jsonLen, cts.Token) != jsonLen) throw new EndOfStreamException();
+
+        var json = Encoding.UTF8.GetString(jsonBuf);
+
+        using var doc = JsonDocument.Parse(json);
+        var players = doc.RootElement.GetProperty("players");
+        int online = players.GetProperty("online").GetInt32();
+        int max    = players.GetProperty("max").GetInt32();
+        
+        return $"{online}/{max}";
+    }
+
+    static async Task SendFramedAsync(NetworkStream stream, byte[] payload, CancellationToken ct)
+    {
+        // Each MC packet is framed as: [VarInt length][payload]
+        using var ms = new MemoryStream();
+        WriteVarInt(ms, payload.Length);
+        ms.Write(payload, 0, payload.Length);
+        var buf = ms.ToArray();
+        await stream.WriteAsync(buf, 0, buf.Length, ct);
+        await stream.FlushAsync(ct);
+    }
+
+    static void WriteVarInt(Stream s, int value)
+    {
+        uint u = (uint)value;
+        while (true)
+        {
+            if ((u & ~0x7Fu) == 0) { s.WriteByte((byte)u); return; }
+            s.WriteByte((byte)((u & 0x7F) | 0x80));
+            u >>= 7;
+        }
+    }
+
+    static void WriteUShort(Stream s, ushort v)
+    {
+        Span<byte> tmp = stackalloc byte[2];
+        BinaryPrimitives.WriteUInt16BigEndian(tmp, v);
+        s.Write(tmp);
+    }
+
+    static void WriteString(Stream s, string str)
+    {
+        var bytes = Encoding.UTF8.GetBytes(str);
+        WriteVarInt(s, bytes.Length);
+        s.Write(bytes, 0, bytes.Length);
+    }
+
+    static async Task<int> ReadVarIntAsync(NetworkStream stream, CancellationToken ct)
+    {
+        int numRead = 0;
+        int result = 0;
+        byte read;
+        do
+        {
+            read = await ReadByteAsync(stream, ct);
+            int value = (read & 0b0111_1111);
+            result |= (value << (7 * numRead));
+            numRead++;
+            if (numRead > 5) throw new InvalidDataException("VarInt too big");
+        } while ((read & 0b1000_0000) != 0);
+        return result;
+    }
+    
+    static int ReadVarInt(Stream s)
+    {
+        int numRead = 0, result = 0, read;
+        do
+        {
+            read = s.ReadByte();
+            if (read == -1) throw new EndOfStreamException();
+            int value = read & 0x7F;
+            result |= value << (7 * numRead++);
+            if (numRead > 5) throw new InvalidDataException("VarInt too big");
+        } while ((read & 0x80) != 0);
+        return result;
+    }
+
+    static async Task<byte[]> ReadExactAsync(NetworkStream stream, int len, CancellationToken ct)
+    {
+        var buf = new byte[len];
+        int off = 0;
+        while (off < len)
+        {
+            int read = await stream.ReadAsync(buf, off, len - off, ct);
+            if (read == 0) throw new EndOfStreamException();
+            off += read;
+        }
+        return buf;
+    }
+    
+    static async Task<byte[]> ReadPacketAsync(NetworkStream stream, CancellationToken ct)
+    {
+        var length  = await ReadVarIntAsync(stream, ct);
+        return await ReadExactAsync(stream, length, ct);
+    }
+
+    static async Task<byte> ReadByteAsync(NetworkStream stream, CancellationToken ct)
+    {
+        var buffer = new byte[1];
+        int read = await stream.ReadAsync(buffer, 0, 1, ct);
+        if (read == 0) throw new EndOfStreamException();
+        return buffer[0];
+    }
+}

--- a/Pelican Keeper/Query Services/RconService.cs
+++ b/Pelican Keeper/Query Services/RconService.cs
@@ -44,7 +44,7 @@ public class RconService(string ip, int port, string password) : ISendCommand, I
         var response = await ReadResponseAsync();
         if (Program.Config.Debug)
             ConsoleExt.WriteLineWithPretext($"RCON command response: {response.body.Trim()}");
-        return response.body.Trim();
+        return response.body.Trim(); //TODO: Do the Player count text format correction here before returning instead of outside the function to streamline the process
     }
 
     public void Dispose()

--- a/Pelican Keeper/Query Services/RconService.cs
+++ b/Pelican Keeper/Query Services/RconService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net.Sockets;
 using System.Text;
 
-namespace Pelican_Keeper;
+namespace Pelican_Keeper.Query_Services;
 
 public class RconService(string ip, int port, string password) : ISendCommand, IDisposable
 {

--- a/Pelican Keeper/ServerMarkdown.cs
+++ b/Pelican Keeper/ServerMarkdown.cs
@@ -80,7 +80,7 @@ public static class ServerMarkdown
 
         if (Program.Config.JoinableIpDisplay)
         {
-            viewModel.IpAndPort = HelperClass.GetConnectableAddress(serverResponse);
+            viewModel.IpAndPort = HelperClass.GetReadableConnectableAddress(serverResponse);
         }
         
         if (Program.Config.PlayerCountDisplay)

--- a/Pelican Keeper/TemplateClasses.cs
+++ b/Pelican Keeper/TemplateClasses.cs
@@ -31,7 +31,8 @@ public abstract class TemplateClasses
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum CommandExecutionMethod
     {
-        Minecraft,
+        MinecraftJava,
+        MinecraftBedrock,
         Rcon,
         A2S
     }
@@ -53,6 +54,7 @@ public abstract class TemplateClasses
         public MessageSorting MessageSorting { get; init; }
         public MessageSortingDirection MessageSortingDirection { get; init; }
         public bool IgnoreOfflineServers { get; init; }
+        public bool IgnoreInternalServers { get; init; }
         public string[]? ServersToIgnore { get; init; }
         
         public bool JoinableIpDisplay { get; init; }

--- a/Pelican Keeper/TemplateClasses.cs
+++ b/Pelican Keeper/TemplateClasses.cs
@@ -64,7 +64,11 @@ public abstract class TemplateClasses
         public string? EmptyServerTimeout { get; init; }
         public bool AllowUserServerStartup { get; init; }
         public string[]? AllowServerStartup { get; init; }
-        
+        public string[]? UsersAllowedToStartServers { get; init; }
+        public bool AllowUserServerStopping { get; init; }
+        public string[]? AllowServerStopping { get; init; }
+        public string[]? UsersAllowedToStopServers { get; init; }
+
         public bool ContinuesMarkdownRead { get; init; }
         public bool ContinuesGamesToMonitorRead { get; init; }
         public int MarkdownUpdateInterval { get; init; }

--- a/Pelican Keeper/TemplateClasses.cs
+++ b/Pelican Keeper/TemplateClasses.cs
@@ -42,7 +42,7 @@ public abstract class TemplateClasses
         public string? ServerToken { get; init; }
         public string? ServerUrl { get; init; }
         public string? BotToken { get; init; }
-        public ulong ChannelId { get; init; }
+        public ulong[]? ChannelIds { get; init; }
         public string? ExternalServerIp { get; init; }
     }
     

--- a/Pelican Keeper/TemplateClasses.cs
+++ b/Pelican Keeper/TemplateClasses.cs
@@ -151,6 +151,7 @@ public abstract class TemplateClasses
         public string? Command { get; set; }
         public string? QueryPortVariable { get; set; }
         public string? MaxPlayerVariable { get; set; }
+        public string? MaxPlayer { get; set; }
         public string? PlayerCountExtractRegex { get; set; }
     }
     

--- a/Pelican Keeper/TemplateClasses.cs
+++ b/Pelican Keeper/TemplateClasses.cs
@@ -31,7 +31,7 @@ public abstract class TemplateClasses
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum CommandExecutionMethod
     {
-        PelicanApi, //Thinking about adding the minecraft protocol as well
+        Minecraft,
         Rcon,
         A2S
     }

--- a/Pelican Keeper/Validator.cs
+++ b/Pelican Keeper/Validator.cs
@@ -1,0 +1,36 @@
+﻿namespace Pelican_Keeper;
+
+public class Validator
+{
+    public static void ValidateSecrets(TemplateClasses.Secrets? secrets)
+    {
+        if (secrets == null)
+        {
+            throw new ArgumentNullException(nameof(secrets), "Secrets object is null.");
+        }
+        if (string.IsNullOrWhiteSpace(secrets.ClientToken))
+        {
+            throw new ArgumentException("ClientToken is null or empty. Make sure to provide a valid Discord client token.");
+        }
+        
+        if (string.IsNullOrWhiteSpace(secrets.ServerToken))
+        {
+            throw new ArgumentException("ServerToken is null or empty. Make sure to provide a valid token.");
+        }
+        
+        if (string.IsNullOrWhiteSpace(secrets.ServerUrl))
+        {
+            throw new ArgumentException("ServerUrl is null or empty. Make sure to provide a valid URL.");
+        }
+        
+        if (string.IsNullOrWhiteSpace(secrets.BotToken))
+        {
+            throw new ArgumentException("BotToken is null or empty. Make sure to provide a valid Discord bot token.");
+        }
+        
+        if (secrets.ChannelIds == null || secrets.ChannelIds.Length == 0)
+        {
+            throw new ArgumentException("ChannelIds is null or empty. Make sure at least one channel ID is provided in the list.");
+        }
+    }
+}


### PR DESCRIPTION
Additions:
- Added user lists for start and stop that are allowed to start and stop servers
- Added manual stop buttons
- Added the ability to run the bot in multiple channels.
- Added a dropdown for consolidated to start and stop servers to get around the Discord button limit
- Added Code and function comments
- Added Minecraft Query
- Added PlayerCount Response test framework for testing the server responses
- Added Bedrock Minecraft Query
- Added internal server player count fetching
- Added an ignore internal servers toggle
- Added Function Summaries
- Added new Minecraft query options to the unit test
- Added a validator for the secrets file that will be more specific about what is wrong with the file
- Added two more games to the GamesToMonitor
- Added the ability to pull the contents of the GamesToMonitor from GitHub
- Added MaxPlayer variable back as an option in GamesToMonitor
- Added missing negate sign to null check for MaxPlayer variable

Changes:
- Changed the default config and secrets to account for the new features.
- A little bit of code organization
- Changed the way files get detected in the program directory
- Condensed some player count detection code
- Fixed Multi-Channel message sending
- Changed the GetFile to look through the entire directory and its sub-directories
- Changed the Java and Bedrock query to be more uniform with the RCON and A2S query
- Changed the way the defaults of the config and the Message Markdown get created by pulling the defaults from GitHub instead
- Code cleanup and de-duplication
- Changed Player Count Display text to be more streamlined
- Simplified the check for player count and a just text response from the server

Fixes:
- Bug fixes
- Fixed Custom Regex not applying to Player Count Display

Removed:
- Removed Pelican API (replaced by Minecraft Query)